### PR TITLE
feat(models): implement one-to-many relationships in models

### DIFF
--- a/PokemonReviewApp/Models/Country.cs
+++ b/PokemonReviewApp/Models/Country.cs
@@ -6,6 +6,7 @@ namespace PokemonReviewApp.Models
     {
         public int Id { get; set; }
         public required string Name { get; set; }
+        public ICollection<Owner> Owners { get; set; }
     }
 }
 

--- a/PokemonReviewApp/Models/Owner.cs
+++ b/PokemonReviewApp/Models/Owner.cs
@@ -7,6 +7,7 @@ namespace PokemonReviewApp.Models
         public int Id { get; set; }
         public required string Name { get; set; }
         public required string Gym { get; set; }
+        public Country Country { get; set; }
     }
 }
 

--- a/PokemonReviewApp/Models/Pokemon.cs
+++ b/PokemonReviewApp/Models/Pokemon.cs
@@ -7,6 +7,7 @@ namespace PokemonReviewApp.Models
         public int Id { get; set; }
         public required string Name { get; set; }
         public DateTime BirthDate { get; set; }
+        public ICollection<Review> Reviews { get; set; }
     }
 }
 

--- a/PokemonReviewApp/Models/Review.cs
+++ b/PokemonReviewApp/Models/Review.cs
@@ -7,6 +7,8 @@ namespace PokemonReviewApp.Models
         public int Id { get; set; }
         public required string Title { get; set; }
         public required string Text { get; set; }
+        public Reviewer Reviewer { get; set; }
+        public Pokemon Pokemon { get; set; }
     }
 }
 

--- a/PokemonReviewApp/Models/Reviewer.cs
+++ b/PokemonReviewApp/Models/Reviewer.cs
@@ -7,6 +7,7 @@ namespace PokemonReviewApp.Models
         public int Id { get; set; }       
         public required string FirstName { get; set; }
         public required string LastName { get; set; }
+        public ICollection<Review> Reviews { get; set; }
     }
 }
 


### PR DESCRIPTION
### Summary

This pull request introduces one-to-many relationships between the models in the Web API. These relationships are essential for representing real-world connections between entities such as Pokémon, their reviews, owners, and reviewers.

### Changes Made

1. **Country.cs**:
   - Added an `ICollection<Owner>` to represent the one-to-many relationship between a country and its owners.

2. **Owner.cs**:
   - Added a reference to `Country` to represent the many-to-one relationship between an owner and their country.

3. **Pokemon.cs**:
   - Added an `ICollection<Review>` to represent the one-to-many relationship between Pokémon and their reviews.

4. **Review.cs**:
   - Added references to both `Reviewer` (many-to-one) and `Pokemon` (many-to-one).

5. **Reviewer.cs**:
   - Added an `ICollection<Review>` to represent the one-to-many relationship between a reviewer and their reviews.

### Why These Changes?

These changes are necessary for building a relational database structure that reflects the application's domain model. By defining these relationships:
- We can easily query related data using Entity Framework Core.
- The application gains flexibility for future features, such as filtering Pokémon by reviews or retrieving all owners from a specific country.

### Testing

- These changes only affect model definitions. Testing will be performed in subsequent features when these models are integrated with the database context and controllers.

### Next Steps

1. Define many-to-many relationships where applicable (e.g., Pokémon categories).
2. Integrate these models into the database context using Entity Framework Core.
3. Create migrations to generate database tables based on these relationships.